### PR TITLE
First draft of making the omniplanner do generic dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,27 @@ ROS node that provides an interface for combining planning commands, scene
 representations, and robot commands, and the Omniplanner non-ROS code that
 defines the generic interfaces that a planner or language grounding system
 needs to implement to work with the Omniplanner node.
+
+The planner plugins that Omniplanner loads are defined in a yaml file like
+[this one](https://github.com/MIT-SPARK/Awesome-DCIST-T4/blob/feature/generic_omniplanner/dcist_launch_system/config/bag/omniplanner_plugins.yaml). The omniplanner node
+takes the path to this [as a rosparam](https://github.com/MIT-SPARK/Awesome-DCIST-T4/blob/feature/generic_omniplanner/dcist_launch_system/config/bag/omniplanner_node.yaml).
+
+Implementing a planner plugin requires implementing Omniplanner's
+`ground_problem` and `make_plan` interface. At planning time, various planning
+and grounding methods can be combined through dispatching on the input and
+output types of these modules. You need to implement [an interface like
+this](https://github.com/MIT-SPARK/Omniplanner/blob/feature/full_genericization/omniplanner/src/omniplanner/goto_points.py)
+to give the omniplanner node a hook into your planning and grounding behavior.
+
+The second thing you need to do is implement the ROS hook. This entails
+writing [a class like this](https://github.com/MIT-SPARK/Omniplanner/blob/feature/full_genericization/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py)
+with a `get_plan_callback` function. You also need to implement the config
+registration at the bottom of the file to enable constructing the plugin
+based on the plugin YAML definition.
+
+Currently, there is a final step of importing your custom config into the
+Omniplanner Node
+[here](https://github.com/MIT-SPARK/Omniplanner/blob/de84ccf5d5f71b6f41b04d9bceb24a11eaeb1fe5/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py#L28),
+but the intention is to do automatic plugin discovery. Automatic plugin
+discovery will enable all downstream planning plugins to be implemented without
+touching the omniplanner node.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Omniplanner
+
+Omniplanner provides an interface to solving DSG-grounded planning problems
+with a variety of solvers and grounding mechanisms. The goal is to enable
+module design of command grounding and planning implementations, and a clean
+hook for transforming the output of a planner into robot-compatible input.
+
+This repo is still under construction, and details are subject to change.
+
+## Architecture
+
+The Omniplanner architecture can be thought of in two halves: The Omniplanner
+ROS node that provides an interface for combining planning commands, scene
+representations, and robot commands, and the Omniplanner non-ROS code that
+defines the generic interfaces that a planner or language grounding system
+needs to implement to work with the Omniplanner node.

--- a/omniplanner/examples/test.py
+++ b/omniplanner/examples/test.py
@@ -35,7 +35,7 @@ points = np.array(
     ]
 )
 
-robot_poses = {"spot", self.get_spot_pose}
+# robot_poses = {"spot", self.get_spot_pose}
 
 req = PlanRequest(
     domain=GotoPointsDomain(),

--- a/omniplanner/src/omniplanner/goto_points.py
+++ b/omniplanner/src/omniplanner/goto_points.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import List, overload
 
@@ -69,6 +70,7 @@ def ground_problem(domain, map_context, start, goal) -> GroundedGotoPointsProble
 
 @dispatch(GroundedGotoPointsProblem, object)
 def make_plan(grounded_problem, map_context) -> GotoPointsPlan:
+    time.sleep(3)
     plan = []
     p = GotoPointPrimitive(
         grounded_problem.start_point, grounded_problem.goal_points[0]

--- a/omniplanner/src/omniplanner/language_planner.py
+++ b/omniplanner/src/omniplanner/language_planner.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from multipledispatch import dispatch
+from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal
+
+
+
+class LanguageDomain:
+    pass
+
+@dataclass
+class LanguageGoal:
+    robot_id: str
+    command: str
+
+
+@dispatch(LanguageDomain, object, dict, LanguageGoal)
+def ground_problem(domain, dsg, robot_states, goal):
+
+
+    ##############################
+    ### TODO: this block is where we take the goal string from the goal, and any other goal or scene graph information,
+    ### and turn it into a specific planning problem. The LLM can decide to set the problem type, which
+    ### implicitly controls which downstream planner is used.
+
+    language_grounded_goal = GotoPointsGoal(goal_points=goal.command.split(' '), robot_id=goal.robot_id)
+    problem_type = GotoPointsDomain()
+    ##############################
+
+    return ground_problem(problem_type, dsg, robot_states, language_grounded_goal)
+

--- a/omniplanner/src/omniplanner/omniplanner.py
+++ b/omniplanner/src/omniplanner/omniplanner.py
@@ -1,5 +1,6 @@
 # examples of planning combinations:
 from dataclasses import dataclass
+from functools import singledispatch
 from typing import Any
 
 from multipledispatch import dispatch
@@ -105,3 +106,8 @@ def full_planning_pipeline(plan_request: PlanRequest, map_context: Any):
     )
     plan = make_plan(grounded_problem, map_context)
     return plan
+
+
+@singledispatch
+def compile_plan(plan, plan_id, robot_name, frame_id):
+    raise NotImplementedError(f"No `compile_plan` implementation for {type(plan)}")

--- a/omniplanner_msgs/CMakeLists.txt
+++ b/omniplanner_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PlanRequestStringMsg.msg"
   "msg/GotoPointsGoalMsg.msg"
+  "msg/LanguageGoalMsg.msg"
 )
 
 

--- a/omniplanner_msgs/msg/LanguageGoalMsg.msg
+++ b/omniplanner_msgs/msg/LanguageGoalMsg.msg
@@ -1,0 +1,2 @@
+string robot_id
+string command

--- a/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import spark_config as sc
+from dataclasses import dataclass
+from robot_executor_interface.action_descriptions import ActionSequence, Follow
+
+from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal, GotoPointsPlan
+from omniplanner.omniplanner import PlanRequest, compile_plan
+from omniplanner_msgs.msg import GotoPointsGoalMsg
+import numpy as np
+
+@compile_plan.register
+def compile_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
+    actions = []
+    for p in plan.plan:
+        xs = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[0], p.goal[0]])
+        ys = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[1], p.goal[1]])
+        p_interp = np.vstack([xs, ys])
+        actions.append(Follow(frame=frame_id, path2d=p_interp.T))
+
+    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
+    return seq
+
+class GotoPointsRos:
+    def __init__(self, config: GotoPointsConfig):
+        self.config = config
+
+    def get_plan_callback(self):
+        return GotoPointsGoalMsg, "goto_points_goal", self.goto_points_callback
+
+    def goto_points_callback(self, msg, robot_poses):
+
+        goal = GotoPointsGoal(
+            goal_points=msg.point_names_to_visit, robot_id=msg.robot_id
+        )
+        req = PlanRequest(
+            domain=GotoPointsDomain(),
+            goal=goal,
+            robot_states=robot_poses,
+        )
+        return req
+
+
+@sc.register_config("omniplanner_pipeline", name="GotoPoints", constructor=GotoPointsRos)
+@dataclass
+class GotoPointsConfig(sc.Config):
+    pass

--- a/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
-import spark_config as sc
+
 from dataclasses import dataclass
+
+import numpy as np
+import spark_config as sc
 from robot_executor_interface.action_descriptions import ActionSequence, Follow
 
 from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal, GotoPointsPlan
 from omniplanner.omniplanner import PlanRequest, compile_plan
 from omniplanner_msgs.msg import GotoPointsGoalMsg
-import numpy as np
+
 
 @compile_plan.register
 def compile_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
@@ -20,6 +23,7 @@ def compile_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
     seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
     return seq
 
+
 class GotoPointsRos:
     def __init__(self, config: GotoPointsConfig):
         self.config = config
@@ -28,7 +32,6 @@ class GotoPointsRos:
         return GotoPointsGoalMsg, "goto_points_goal", self.goto_points_callback
 
     def goto_points_callback(self, msg, robot_poses):
-
         goal = GotoPointsGoal(
             goal_points=msg.point_names_to_visit, robot_id=msg.robot_id
         )
@@ -40,7 +43,9 @@ class GotoPointsRos:
         return req
 
 
-@sc.register_config("omniplanner_pipeline", name="GotoPoints", constructor=GotoPointsRos)
+@sc.register_config(
+    "omniplanner_pipeline", name="GotoPoints", constructor=GotoPointsRos
+)
 @dataclass
 class GotoPointsConfig(sc.Config):
     pass

--- a/omniplanner_ros/src/omniplanner_ros/language_planner_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/language_planner_ros.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import spark_config as sc
+from dataclasses import dataclass
+from omniplanner.language_planner import LanguageDomain, LanguageGoal
+from omniplanner.omniplanner import PlanRequest
+from omniplanner_msgs.msg import LanguageGoalMsg
+
+class LanguagePlannerRos:
+    def __init__(self, config: LanguagePlannerConfig):
+        self.config = config
+
+    def get_plan_callback(self):
+        return LanguageGoalMsg, "language_goal", self.language_callback
+
+    def language_callback(self, msg, robot_poses):
+
+        ### TODO: Any information that we need to add to the LanguageGoalMsg needs to get piped through
+        ### to this language goal
+        goal = LanguageGoal(command=msg.command, robot_id=msg.robot_id)
+
+        req = PlanRequest(
+            domain=LanguageDomain(),
+            goal=goal,
+            robot_states=robot_poses,
+        )
+        return req
+
+
+@sc.register_config("omniplanner_pipeline", name="LanguagePlanner", constructor=LanguagePlannerRos)
+@dataclass
+class LanguagePlannerConfig(sc.Config):
+    pass

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -25,6 +25,7 @@ from omniplanner.omniplanner import compile_plan, full_planning_pipeline
 
 # TODO: get this import either through __init__.py or autodiscovery
 from omniplanner_ros.goto_points_ros import GotoPointsConfig  # NOQA
+from omniplanner_ros.language_planner_ros import LanguagePlannerConfig  # NOQA
 
 
 @dataclass
@@ -209,6 +210,7 @@ class OmniPlannerRos(Node):
             with self.current_planner_lock and self.plan_time_start_lock:
                 self.current_planner = None
                 self.plan_time_start = None
+            self.get_logger().info("Published Plan")
 
         resolved_topic_name = name + "/" + topic
         self.get_logger().info(

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -1,6 +1,8 @@
 import threading
 import time
 import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict
 
 import numpy as np
 import rclpy
@@ -11,34 +13,36 @@ from hydra_ros import DsgSubscriber
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
-from robot_executor_interface.action_descriptions import ActionSequence, Follow
 from robot_executor_interface_ros.action_descriptions_ros import to_msg, to_viz_msg
 from robot_executor_msgs.msg import ActionSequenceMsg
 from ros_system_monitor_msgs.msg import NodeInfoMsg
+from spark_config import Config, config_field
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 from visualization_msgs.msg import MarkerArray
 
-from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal
-from omniplanner.omniplanner import PlanRequest, full_planning_pipeline
-from omniplanner_msgs.msg import GotoPointsGoalMsg
+from omniplanner.omniplanner import compile_plan, full_planning_pipeline
+
+# TODO: get this import either through __init__.py or autodiscovery
+from omniplanner_ros.goto_points_ros import GotoPointsConfig  # NOQA
 
 
-# TODO: this needs to move somewhere and become generic
-def temp_compile_plan(plan, plan_id, robot_name, frame_id):
-    actions = []
-    for p in plan.plan:
-        xs = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[0], p.goal[0]])
-        ys = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[1], p.goal[1]])
-        p_interp = np.vstack([xs, ys])
-        actions.append(Follow(frame=frame_id, path2d=p_interp.T))
+@dataclass
+class PlannerConfig(Config):
+    plugin: Any = config_field("omniplanner_pipeline", required=False)
 
-    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
-    return seq
+
+@dataclass
+class OmniplannerNodeConfig(Config):
+    planners: Dict[str, PlannerConfig] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: str):
+        return Config.load(OmniplannerNodeConfig, path)
 
 
 def get_robot_pose(
-    tf_buffer, target_frame: str = "map", source_frame: str = "base_link"
+    tf_buffer, target_frame: str = "map", source_frame: str = "spot/base_link"
 ) -> np.ndarray:
     """
     Looks up the transform from target_frame to source_frame and returns [x, y, z, yaw].
@@ -97,13 +101,6 @@ class OmniPlannerRos(Node):
         self.current_planner_lock = threading.Lock()
         self.plan_time_start_lock = threading.Lock()
 
-        self.goto_plan_sub = self.create_subscription(
-            GotoPointsGoalMsg,
-            "~/goto_points_goal",
-            self.goto_points_callback,
-            1,
-        )
-
         self.dsg_lock = threading.Lock()
         DsgSubscriber(self, "~/dsg_in", self.dsg_callback)
 
@@ -119,20 +116,22 @@ class OmniPlannerRos(Node):
             MarkerArray, "~/compiled_plan_viz_out", 1
         )
 
-        # self.pddl_plan_sub = self.create_subscription(
-        #    PddlGoalMsg, "~/pddl_goal", self.pddl_goal_callback, 1
-        # )
-
-        # self.nlp_plan_sub = self.create_subscription(
-        #    NlpGoalMsg, "~/nlp_goal", self.nlp_goal_callback, 1
-        # )
-
         self.heartbeat_pub = self.create_publisher(NodeInfoMsg, "~/node_status", 1)
         heartbeat_timer_group = MutuallyExclusiveCallbackGroup()
         timer_period_s = 0.1
         self.timer = self.create_timer(
             timer_period_s, self.hb_callback, callback_group=heartbeat_timer_group
         )
+
+        # process virtual config
+        self.declare_parameter("plugin_config_path", "")
+        config_path = self.get_parameter("plugin_config_path").value
+        assert config_path != "", "plugin_config_path cannot be empty"
+
+        self.config = OmniplannerNodeConfig.load(config_path)
+        for name, planner in self.config.planners.items():
+            plugin = planner.plugin.create()
+            self.register_plugin(name, plugin)
 
     def dsg_callback(self, header, dsg):
         self.get_logger().warning("Setting DSG!")
@@ -172,62 +171,55 @@ class OmniPlannerRos(Node):
         msg.notes = notes
         self.heartbeat_pub.publish(msg)
 
-    # def nlp_goal_callback(self, msg):
-    #    pass
-
     def get_spot_pose(self):
         # TODO: parameters
         return get_robot_pose(
-            self.tf_buffer, target_frame="map", source_frame="base_link"
+            self.tf_buffer, target_frame="map", source_frame="spot/base_link"
         )
 
-    def goto_points_callback(self, msg):
-        """TODO: in reality, this callback (and the subscription) should be
-        loaded from an external plugin
-        """
+    def register_plugin(self, name, plugin):
+        self.get_logger().info(f"Registering subscription plugin {name}")
+        msg_type, topic, callback = plugin.get_plan_callback()
 
-        # The plugin should provide a function that is (msg, dsg) --> compiled
-        # plan. Publish/visualizing the plan is handled by Omnimapper (although
-        # it requires that the compiled plan implements the visualizer
-        # interface).
+        def plan_handler(msg):
+            self.get_logger().info(f"Handling plan for plugin {name}")
 
-        # We make the restriction that ALL world state is captured by either 1)
-        # the scene graph (or scene graph replacement), or 2) the initial robot
-        # poses
+            if self.dsg_last is None:
+                self.get_logger().error("Got plan request, but no DSG!")
+                return
 
-        if self.dsg_last is None:
-            self.get_logger().error("Got plan request, but no DSG!")
-            return
+            with self.current_planner_lock and self.plan_time_start_lock:
+                self.current_planner = name
+                self.plan_time_start = time.time()
 
-        with self.current_planner_lock and self.plan_time_start_lock:
-            self.current_planner = "GotoPointsPlanner"
-            self.plan_time_start = time.time()
+            robot_poses = {"spot": self.get_spot_pose()}
 
-        robot_poses = {"spot": self.get_spot_pose()}
-        goal = GotoPointsGoal(
-            goal_points=msg.point_names_to_visit, robot_id=msg.robot_id
+            plan_request = callback(msg, robot_poses)
+            with self.dsg_lock:
+                plan = full_planning_pipeline(plan_request, self.dsg_last)
+
+            spot_path_frame = "map"  # TODO: parameter
+            compiled_plan = compile_plan(
+                plan, str(uuid.uuid4()), "spot", spot_path_frame
+            )
+
+            self.compiled_plan_pub.publish(to_msg(compiled_plan))
+            self.compiled_plan_viz_pub.publish(to_viz_msg(compiled_plan, name))
+
+            with self.current_planner_lock and self.plan_time_start_lock:
+                self.current_planner = None
+                self.plan_time_start = None
+
+        resolved_topic_name = name + "/" + topic
+        self.get_logger().info(
+            f"Registering subscription for {resolved_topic_name} (type {str(msg_type)})"
         )
-        req = PlanRequest(
-            domain=GotoPointsDomain(),
-            goal=goal,
-            robot_states=robot_poses,
+        self.create_subscription(
+            msg_type,
+            f"~/{resolved_topic_name}",
+            plan_handler,
+            1,
         )
-
-        with self.dsg_lock:
-            plan = full_planning_pipeline(req, self.dsg_last)
-        spot_path_frame = "map"  # TODO: parameter
-        compiled_plan = temp_compile_plan(
-            plan, str(uuid.uuid4()), "spot", spot_path_frame
-        )
-
-        # 1. Publish compiled plan <-- probably also should happen from omniplanner, not plugin
-        self.compiled_plan_pub.publish(to_msg(compiled_plan))
-        # 2. Publish compiled plan viz <-- should happen from omniplanner, not inside plugin
-        self.compiled_plan_viz_pub.publish(to_viz_msg(compiled_plan, "goto_pt_plan"))
-
-        with self.current_planner_lock and self.plan_time_start_lock:
-            self.current_planner = None
-            self.plan_time_start = None
 
 
 def main(args=None):


### PR DESCRIPTION
Finishing making omniplanner generic. *No* planner-specific code should live inside the `omniplanner_ros` node itself. Instead, planners are loaded via plugin. The plugins define endpoints that will map messages on a specific ROS into a planning problem description that can be handled by generic dispatch. 

This will probably require a little more documentation before it's comprehensible to anyone else, but it's actually pretty straightforward. 

Any planner needs to implement something that looks like the following two files:
```
omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
omniplanner/src/omniplanner/goto_points.py
```
The former defines the mapping from a ROS topic to a Plan specification. 
A plan specification is *not* a fully-grounded planning problem. Rather, it is a collection of all of the information needed to *ask* the planning question (where grounding may be part of the challenge). 
The latter defines functions that can ground / solve the plan. 