### PR TITLE
Add symbolic context

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ but the intention is to do automatic plugin discovery. Automatic plugin
 discovery will enable all downstream planning plugins to be implemented without
 touching the omniplanner node.
 
+There's an edge case in `compile_plan` that may require special care: If the
+output from your planner (your "plan" type) is a subclass of list, then you
+need to implement a `compile_plan` override for `compile_plan(adaptor,
+SymbolicContext[YourPlanType])` *even if you do not need the symbolic context*.
+This issue is caused by limitations of generic type inference of parameterized
+types. You can choose to either not inherit from list, or ensure that you have
+this compile plan override implemented.
+
 ### Is Omniplanner right for me?
 
 Omniplanner is inherently experimental in nature, but it seems to work pretty

--- a/omniplanner/examples/goto_points_example.py
+++ b/omniplanner/examples/goto_points_example.py
@@ -1,6 +1,4 @@
 import numpy as np
-
-# from robot_executor_interface.action_descriptions import ActionSequence, Follow
 from utils import DummyRobotPlanningAdaptor, build_test_dsg
 
 from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal

--- a/omniplanner/examples/language_example.py
+++ b/omniplanner/examples/language_example.py
@@ -4,59 +4,25 @@ from importlib.resources import as_file, files
 import dsg_pddl.domains
 import nlu_interface.resources
 import numpy as np
-from dsg_pddl.dsg_pddl_interface import PddlDomain, PddlPlan
+from dsg_pddl.pddl_grounding import PddlDomain
 from nlu_interface.llm_interface import OpenAIWrapper
-from robot_executor_interface.action_descriptions import ActionSequence, Follow, Gaze
 from ruamel.yaml import YAML
-from utils import build_test_dsg
+from utils import DummyRobotPlanningAdaptor, build_test_dsg
 
 from omniplanner.language_planner import LanguageDomain, LanguageGoal
 from omniplanner.omniplanner import (
     PlanRequest,
     full_planning_pipeline,
 )
+from omniplanner_ros.pddl_planner_ros import compile_plan
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
 
 yaml = YAML(typ="safe")
 
-
-def compile_plan_goto(plan, plan_id, robot_name, frame_id):
-    """This function turns the output of the planner into a ROS message that is ingestible by a robot"""
-    actions = []
-    for p in plan.plan:
-        xs = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[0], p.goal[0]])
-        ys = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[1], p.goal[1]])
-        p_interp = np.vstack([xs, ys])
-        actions.append(Follow(frame=frame_id, path2d=p_interp.T))
-
-    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
-    return seq
-
-
-def compile_plan(plan: PddlPlan, plan_id, robot_name, frame_id):
-    actions = []
-    for symbolic_action, parameters in zip(
-        plan.symbolic_actions, plan.parameterized_actions
-    ):
-        match symbolic_action[0]:
-            case "goto-poi":
-                actions.append(Follow(frame=frame_id, path2d=parameters))
-            case "inspect":
-                robot_point, gaze_point = parameters
-                actions.append(
-                    Gaze(
-                        frame=frame_id,
-                        robot_point=robot_point,
-                        gaze_point=gaze_point,
-                        stow_after=True,
-                    )
-                )
-
-    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
-    return seq
-
+adaptor = DummyRobotPlanningAdaptor("spot", "spot", "map", "body")
+adaptors = {"euclid": adaptor}
 
 print("================================")
 print("== Goto Point Language Domain ==")
@@ -80,9 +46,7 @@ robot_plan = full_planning_pipeline(req, G)
 print("Plan from planning domain:")
 print(robot_plan)
 
-compiled_plan = compile_plan_goto(
-    robot_plan.value, "abc123", robot_plan.name, "a_coordinate_frame"
-)
+compiled_plan = compile_plan(adaptor, robot_plan)
 print("compiled plan:")
 print(compiled_plan)
 
@@ -141,8 +105,6 @@ print("Plan from planning domain:")
 print(plan)
 
 
-compiled_plan = compile_plan(
-    plan[0].value, "abc123", plan[0].name, "a_coordinate_frame"
-)
+compiled_plan = compile_plan(adaptors, plan)
 print("compiled plan:")
 print(compiled_plan)

--- a/omniplanner/examples/pddl_example.py
+++ b/omniplanner/examples/pddl_example.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from importlib.resources import as_file, files
 
 import dsg_pddl.domains
@@ -7,8 +6,10 @@ import numpy as np
 import spark_dsg
 from dsg_pddl.pddl_grounding import PddlDomain, PddlGoal
 from ruamel.yaml import YAML
+from utils import DummyRobotPlanningAdaptor
 
-from omniplanner.omniplanner import PlanRequest, collect_plans, full_planning_pipeline
+from omniplanner.compile_plan import collect_plans
+from omniplanner.omniplanner import PlanRequest, full_planning_pipeline
 from omniplanner_ros.pddl_planner_ros import compile_plan
 
 logging.basicConfig()
@@ -23,14 +24,6 @@ yaml = YAML(typ="safe")
 G = spark_dsg.DynamicSceneGraph.load(
     "/home/ubuntu/lxc_datashare/west_point_fused_map_wregions_labelspace.json"
 )
-
-
-@dataclass
-class DummyRobotPlanningAdaptor:
-    name: str
-    robot_type: str
-    parent_frame: str
-    child_frame: str
 
 
 adaptor = DummyRobotPlanningAdaptor("euclid", "spot", "map", "body")

--- a/omniplanner/examples/pddl_example.py
+++ b/omniplanner/examples/pddl_example.py
@@ -1,24 +1,15 @@
 import logging
+from dataclasses import dataclass
 from importlib.resources import as_file, files
 
 import dsg_pddl.domains
 import numpy as np
 import spark_dsg
-from dsg_pddl.dsg_pddl_planning import PddlPlan
 from dsg_pddl.pddl_grounding import PddlDomain, PddlGoal
-from robot_executor_interface.action_descriptions import (
-    ActionSequence,
-    Follow,
-    Gaze,
-    Pick,
-    Place,
-)
 from ruamel.yaml import YAML
 
-from omniplanner.omniplanner import (
-    PlanRequest,
-    full_planning_pipeline,
-)
+from omniplanner.omniplanner import PlanRequest, collect_plans, full_planning_pipeline
+from omniplanner_ros.pddl_planner_ros import compile_plan
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
@@ -26,59 +17,24 @@ logging.getLogger().setLevel(logging.INFO)
 yaml = YAML(typ="safe")
 
 
-def compile_plan(plan: PddlPlan, plan_id, robot_name, frame_id):
-    actions = []
-    for symbolic_action, parameters in zip(
-        plan.symbolic_actions, plan.parameterized_actions
-    ):
-        match symbolic_action[0]:
-            case "goto-poi":
-                actions.append(Follow(frame=frame_id, path2d=parameters))
-            case "inspect":
-                robot_point, gaze_point = parameters
-                actions.append(
-                    Gaze(
-                        frame=frame_id,
-                        robot_point=robot_point,
-                        gaze_point=gaze_point,
-                        stow_after=True,
-                    )
-                )
-            case "pick-object":
-                robot_point, pick_point = parameters
-                actions.append(
-                    Pick(
-                        frame=frame_id,
-                        object_class="",
-                        robot_point=robot_point,
-                        object_point=pick_point,
-                    )
-                )
-            case "place-object":
-                robot_point, place_point = parameters
-                actions.append(
-                    Place(
-                        frame=frame_id,
-                        object_class="",
-                        robot_point=robot_point,
-                        object_point=place_point,
-                    )
-                )
-            case _:
-                raise NotImplementedError(
-                    f"I don't know how to compile {symbolic_action[0]}"
-                )
-
-    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
-    return seq
-
-
 # G = build_test_dsg()
 # goal = PddlGoal(robot_id="euclid", pddl_goal="(and (visited-object o0) (visited-object o1))")
 # goal = PddlGoal(robot_id="euclid", pddl_goal="(object-in-place o1 p0)")
 G = spark_dsg.DynamicSceneGraph.load(
-    "/home/ubuntu/lxc_datashare/west_point_fused_map_wregions.json"
+    "/home/ubuntu/lxc_datashare/west_point_fused_map_wregions_labelspace.json"
 )
+
+
+@dataclass
+class DummyRobotPlanningAdaptor:
+    name: str
+    robot_type: str
+    parent_frame: str
+    child_frame: str
+
+
+adaptor = DummyRobotPlanningAdaptor("euclid", "spot", "map", "body")
+adaptors = {"euclid": adaptor}
 
 robot_poses = {"euclid": np.array([0.0, 0.1])}
 
@@ -113,9 +69,12 @@ plan = full_planning_pipeline(req, G)
 print("Plan from planning domain:")
 print(plan)
 
-compiled_plan = compile_plan(plan.value, "abc123", plan.name, "a_coordinate_frame")
-print("compiled plan:")
+compiled_plan = compile_plan(adaptors, plan)
 print(compiled_plan)
+
+collected_plans = collect_plans(compiled_plan)
+print("Collected plans:")
+print(collected_plans)
 
 
 print("================================")
@@ -146,9 +105,9 @@ plan = full_planning_pipeline(req, G)
 print("Plan from planning domain:")
 print(plan)
 
-compiled_plan = compile_plan(plan.value, "abc123", plan.name, "a_coordinate_frame")
-print("compiled plan:")
-print(compiled_plan)
+collected_plan = collect_plans(compile_plan(adaptors, plan))
+print("collected plan: ", collected_plan)
+
 
 print("================================")
 print("==   PDDL Domain (Regions)    ==")
@@ -186,6 +145,6 @@ plan = full_planning_pipeline(req, G)
 print("Plan from planning domain:")
 print(plan)
 
-compiled_plan = compile_plan(plan.value, "abc123", plan.name, "a_coordinate_frame")
-print("compiled plan:")
-print(compiled_plan)
+
+collected_plan = collect_plans(compile_plan(adaptors, plan))
+print("collected plan: ", collected_plan)

--- a/omniplanner/examples/tsp_example.py
+++ b/omniplanner/examples/tsp_example.py
@@ -1,33 +1,26 @@
 import logging
 
 import numpy as np
-from robot_executor_interface.action_descriptions import ActionSequence, Follow
-from utils import build_test_dsg
+from utils import DummyRobotPlanningAdaptor, build_test_dsg
 
 from omniplanner.omniplanner import (
     PlanRequest,
     full_planning_pipeline,
 )
-from omniplanner.tsp import FollowPathPlan, TspDomain, TspGoal
+from omniplanner.tsp import TspDomain, TspGoal
+from omniplanner_ros.goto_points_ros import compile_plan
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
-
-def compile_plan(plan: FollowPathPlan, plan_id, robot_name, frame_id):
-    actions = []
-    for p in plan:
-        actions.append(Follow(frame=frame_id, path2d=p.path))
-    seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
-    return seq
-
+adaptor = DummyRobotPlanningAdaptor("euclid", "spot", "map", "body")
 
 print("==========================")
 print("== TSP Domain           ==")
 print("==========================")
 print("")
 
-goal = TspGoal(goal_points=["o(0)", "o(1)"], robot_id="spot")
+goal = TspGoal(goal_points=["O(0)", "O(1)"], robot_id="spot")
 
 robot_domain = TspDomain(solver="2opt")
 
@@ -45,8 +38,6 @@ robot_plan = full_planning_pipeline(req, G)
 print("Plan from planning domain:")
 print(robot_plan)
 
-compiled_plan = compile_plan(
-    robot_plan.value, "abc123", robot_plan.name, "a_coordinate_frame"
-)
+compiled_plan = compile_plan(adaptor, robot_plan)
 print("compiled plan:")
 print(compiled_plan)

--- a/omniplanner/examples/utils.py
+++ b/omniplanner/examples/utils.py
@@ -1,5 +1,15 @@
+from dataclasses import dataclass
+
 import numpy as np
 import spark_dsg
+
+
+@dataclass
+class DummyRobotPlanningAdaptor:
+    name: str
+    robot_type: str
+    parent_frame: str
+    child_frame: str
 
 
 def build_test_dsg():

--- a/omniplanner/examples/wrapper_test.py
+++ b/omniplanner/examples/wrapper_test.py
@@ -1,0 +1,190 @@
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, List, overload
+
+from plum import dispatch
+
+from omniplanner.functor import fmap
+from omniplanner.omniplanner import RobotWrapper, SymbolicContext, Wrapper
+
+# Wrapper typeclass:
+# extract -- return the wrapped value
+# with_new_value -- set the wrapper's value to a new value
+# push -- (get automatically from extract and with_new_value) -- swap the order of wrappers
+# You can choose which "depths" to swap in a stack of wrappers by composing fmap: fmap(push, wrapper) will leave the top-layer wrapper alone and swap the next two layers
+
+
+@overload
+@dispatch
+def extract(x: RobotWrapper):
+    return x.value
+
+
+@dispatch
+def extract(x: SymbolicContext):
+    return x.value
+
+
+@overload
+@dispatch
+def with_new_value(x: RobotWrapper, value):
+    return RobotWrapper(x.name, value)
+
+
+@dispatch
+def with_new_value(x: SymbolicContext, value):
+    return SymbolicContext(x.context, value)
+
+
+@dispatch
+def push(x: Wrapper):
+    """Really we want to specify Wrapper[Wrapper[Any]], but I couldn't get type inference to work"""
+    inner_wrapper = extract(x)
+    if not isinstance(inner_wrapper, Wrapper) and not isinstance(inner_wrapper, List):
+        raise TypeError("Can only push type Wrapper[Wrapper[T]]")
+    return fmap(lambda val: with_new_value(x, val), inner_wrapper)
+
+
+a = RobotWrapper("jasper", 1)
+print(a)
+
+b = SymbolicContext({"jasper": {"robot_type": "spot"}}, a)
+
+print(b)
+
+c = push(b)
+
+print(c)
+
+t = RobotWrapper("jasper", [1, 2, 3])
+print(push(t))
+
+
+@dataclass
+class TempPddlPlan:
+    fake_action: int
+
+
+@dataclass
+class FakeTsp:
+    order: list
+
+
+@dataclass
+class FakeAction:
+    name: str
+    action: int
+
+
+@dataclass
+class Adaptor:
+    robot_name: str
+
+
+@dataclass
+class Plan:
+    pass
+
+
+@dataclass
+class MyListPlan(list, Plan):
+    val: 1
+
+
+@overload
+@dispatch
+def compile_plan(adaptors, p: SymbolicContext[List[Any]]) -> List[RobotWrapper[Any]]:
+    return fmap(partial(compile_plan, adaptors), push(p))
+
+
+@overload
+@dispatch
+def compile_plan(adaptors, p: SymbolicContext[RobotWrapper[Any]]) -> RobotWrapper[Any]:
+    robot_symbolic = push(p)
+    adaptor = adaptors[robot_symbolic.name]
+    return fmap(partial(compile_plan, adaptor), robot_symbolic)
+
+
+@overload
+@dispatch
+def compile_plan(adaptor, p: SymbolicContext[int]):
+    return str(p.value)
+
+
+# NOTE: this is the signature that you would modify to introduce a compiler for
+# a new robot or Abstract Plan type. If we wanted to support different kinds of
+# adaptors, that we would dispatch on adaptor here too (currently we assume all
+# adaptors are for interfacing with RobotExecutor interface, but if we had e.g.
+# a Phoenix interface, then that would be implemented as a separate adaptor
+# type.
+@overload
+@dispatch
+def compile_plan(adaptor, p: SymbolicContext[TempPddlPlan]):
+    return FakeAction(adaptor.robot_name, p.value.fake_action)
+
+
+# Test analogous to the compiler for TspPlan
+@overload
+@dispatch
+def compile_plan(adaptor, p: Wrapper):
+    return compile_plan(adaptor, extract(p))
+
+
+@overload
+@dispatch
+def compile_plan(adaptor, p: FakeTsp):
+    return FakeAction(adaptor.robot_name + "_tsp", p.order)
+
+
+@dispatch
+def compile_plan(adaptor, p: SymbolicContext[MyListPlan]):
+    return FakeAction(adaptor.robot_name, p.value.val)
+
+
+@overload
+@dispatch
+def collect_plans(p: List[RobotWrapper[Any]]):
+    # TODO: should we warn about duplicate names in robot wrappers?
+    return {r.name: r.value for r in p}
+
+
+@dispatch
+def collect_plans(p: RobotWrapper[Any]):
+    return {p.name: p.value}
+
+
+adaptors = {"jasper": Adaptor("jasper")}
+
+plan1 = SymbolicContext({"p1": {"class": "tree"}}, 1)
+
+print("compiled_plan 1: ")
+print(compile_plan(adaptors["jasper"], plan1))
+#
+# plan2 = SymbolicContext({"p1": {"class": "tree"}}, [RobotWrapper("jasper", 1)])
+#
+# print("compiled_plan 2: ")
+# print(compile_plan(plan2, adaptors))
+# print("collected_plan 2: ")
+# print(collect_plans(compile_plan(adaptors, plan2)))
+
+
+plan3 = SymbolicContext(
+    {"p1": {"class": "tree"}}, RobotWrapper("jasper", TempPddlPlan(42))
+)
+print(compile_plan(adaptors, plan3))
+print(collect_plans(compile_plan(adaptors, plan3)))
+
+# Test "skipping" the symbolic context wrapper
+plan4 = SymbolicContext(
+    {"p1": {"class": "tree"}}, RobotWrapper("jasper", FakeTsp([1, 2, 3]))
+)
+print(compile_plan(adaptors, plan4))
+print(collect_plans(compile_plan(adaptors, plan4)))
+
+
+# Tricky edge case where the plan is derived from a list
+plan5 = SymbolicContext(
+    {"p1": {"class": "tree"}}, RobotWrapper("jasper", MyListPlan(12))
+)
+print(compile_plan(adaptors, plan5))
+print(collect_plans(compile_plan(adaptors, plan5)))

--- a/omniplanner/src/dsg_pddl/dsg_pddl_grounding.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_grounding.py
@@ -261,6 +261,9 @@ def generate_place_containment(G):
         place_centers.append(node.attributes.position)
         place_nodes.append(node)
     place_centers = np.array(place_centers)
+    if len(place_centers) == 0:
+        # there are no 3d places, so we don't need to worry about place/region containment
+        return []
 
     for node in places_layer_2d.nodes:
         closest_idx = np.argmin(

--- a/omniplanner/src/dsg_pddl/dsg_pddl_grounding.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_grounding.py
@@ -12,7 +12,7 @@ from dsg_pddl.pddl_grounding import (
     PddlProblem,
     PddlSymbol,
 )
-from dsg_pddl.pddl_utils import extract_facts, lisp_string_to_ast
+from dsg_pddl.pddl_utils import extract_facts, lisp_string_to_ast, pddl_char_to_dsg_char
 from omniplanner.omniplanner import RobotWrapper
 from omniplanner.tsp import LayerPlanner
 
@@ -321,21 +321,6 @@ def extract_symbols_of_interest(G, pddl_goal):
 
 def simplify(pddl):
     return pddl
-
-
-# PDDL is case-insensitive, but spark_dsg is case sensitive.
-# Here to convert back and forth, but this is *extremely* brittle.
-def pddl_char_to_dsg_char(c):
-    match c:
-        case "r":
-            return "R"
-        case "o":
-            return "O"
-        case "p":
-            # NOTE: this means we can only ground to 2d places, not 3d places
-            return "P"
-        case _:
-            return c
 
 
 def add_symbol_positions(G, symbols):

--- a/omniplanner/src/dsg_pddl/pddl_utils.py
+++ b/omniplanner/src/dsg_pddl/pddl_utils.py
@@ -48,3 +48,18 @@ def ast_to_string(ast):
             return f"({elements_str})"
         case _:
             return str(ast)
+
+
+# PDDL is case-insensitive, but spark_dsg is case sensitive.
+# Here to convert back and forth, but this is *extremely* brittle.
+def pddl_char_to_dsg_char(c):
+    match c:
+        case "r":
+            return "R"
+        case "o":
+            return "O"
+        case "p":
+            # NOTE: this means we can only ground to 2d places, not 3d places
+            return "P"
+        case _:
+            return c

--- a/omniplanner/src/omniplanner/compile_plan.py
+++ b/omniplanner/src/omniplanner/compile_plan.py
@@ -1,0 +1,61 @@
+import logging
+from functools import partial
+from typing import Any, List, overload
+
+from plum import dispatch
+
+from omniplanner.omniplanner import (
+    RobotWrapper,
+    SymbolicContext,
+    Wrapper,
+    extract,
+    fmap,
+    push,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@overload
+@dispatch
+def compile_plan(adaptors, p: SymbolicContext[List[Any]]) -> List[RobotWrapper[Any]]:
+    logger.warning(f"SymbolicContext[List[Any]] with: {type(p)}")
+    return fmap(partial(compile_plan, adaptors), push(p))
+
+
+@overload
+@dispatch
+def compile_plan(adaptors, p: SymbolicContext[RobotWrapper[Any]]) -> RobotWrapper[Any]:
+    logger.warning(f"SymbolicContext[RobotWrapper[Any]] with: {type(p)}")
+    robot_symbolic = push(p)
+    adaptor = adaptors[robot_symbolic.name]
+    return fmap(partial(compile_plan, adaptor), robot_symbolic)
+
+
+# NOTE: this is the signature that you would modify to introduce a compiler for
+# a new robot or Abstract Plan type. If we wanted to support different kinds of
+# adaptors, that we would dispatch on adaptor here too (currently we assume all
+# adaptors are for interfacing with RobotExecutor interface, but if we had e.g.
+# a Phoenix interface, then that would be implemented as a separate adaptor
+# type.
+# @dispatch
+# def compile_plan(adaptor, p: SymbolicContext[PddlPlan]):
+#    return FakeExecutorAction(adaptor.robot_name, p.value.fake_action)
+
+
+@overload
+@dispatch
+def collect_plans(p: List[RobotWrapper[Any]]):
+    # TODO: should we warn about duplicate names in robot wrappers?
+    return {r.name: r.value for r in p}
+
+
+@dispatch
+def collect_plans(p: RobotWrapper[Any]):
+    return {p.name: p.value}
+
+
+# This implementation lets the compilation process transparently "skip" unused wrappers
+@dispatch
+def compile_plan(adaptor, p: Wrapper):
+    return compile_plan(adaptor, extract(p))

--- a/omniplanner/src/omniplanner/compile_plan.py
+++ b/omniplanner/src/omniplanner/compile_plan.py
@@ -25,7 +25,9 @@ def compile_plan(adaptors, p: SymbolicContext[List[Any]]) -> List[RobotWrapper[A
 
 @overload
 @dispatch
-def compile_plan(adaptors, p: SymbolicContext[RobotWrapper[Any]]) -> RobotWrapper[Any]:
+def compile_plan(
+    adaptors: dict, p: SymbolicContext[RobotWrapper[Any]]
+) -> RobotWrapper[Any]:
     logger.warning(f"SymbolicContext[RobotWrapper[Any]] with: {type(p)}")
     robot_symbolic = push(p)
     adaptor = adaptors[robot_symbolic.name]

--- a/omniplanner/src/omniplanner/functor.py
+++ b/omniplanner/src/omniplanner/functor.py
@@ -12,8 +12,6 @@ class FunctorTrait:
 Functor = Union[FunctorTrait, Iterable]
 
 
-# This function will do type inferences properly for dataclass in plum,
-# but I don't think we actually need that functionality right now?
 def generic_inference(K):
     @classmethod
     def inference_function(self, *args):

--- a/omniplanner/src/omniplanner/language_planner.py
+++ b/omniplanner/src/omniplanner/language_planner.py
@@ -36,11 +36,8 @@ def ground_problem(
             goal_points=goal.command.split(" "), robot_id=goal.robot_id
         )
         problem_type = GotoPointsDomain()
-        return RobotWrapper(
-            goal.robot_id,
-            ground_problem(
-                problem_type, dsg, robot_states, language_grounded_goal, feedback
-            ),
+        return ground_problem(
+            problem_type, dsg, robot_states, language_grounded_goal, feedback
         )
     elif domain.domain_type == "Pddl":
         # Query the LLM & Parse the response

--- a/omniplanner/src/omniplanner/omniplanner.py
+++ b/omniplanner/src/omniplanner/omniplanner.py
@@ -1,10 +1,12 @@
 # examples of planning combinations:
 import logging
+from collections import UserDict
 from dataclasses import dataclass
-from functools import singledispatch
-from typing import Any, Callable, overload
+from typing import Any, Callable, List, overload
 
+from dsg_pddl.pddl_utils import pddl_char_to_dsg_char
 from plum import dispatch
+from spark_dsg import NodeSymbol
 
 from omniplanner.functor import Functor, FunctorTrait, dispatchable_parametric
 
@@ -55,15 +57,156 @@ class Plan:
     pass
 
 
+class Wrapper(FunctorTrait):
+    pass
+
+
+@overload
+@dispatch
+def fmap(fn: Callable, wrapper: Wrapper):
+    return with_new_value(wrapper, fn(extract(wrapper)))
+
+
+@dispatch
+def push(x: Wrapper):
+    """Really we want to specify Wrapper[Wrapper[Any]], but I couldn't get type inference to work"""
+    inner_wrapper = extract(x)
+    if not isinstance(inner_wrapper, Wrapper) and not isinstance(inner_wrapper, List):
+        raise TypeError("Can only push type Wrapper[Wrapper[T]]")
+    return fmap(lambda val: with_new_value(x, val), inner_wrapper)
+
+
 @dispatchable_parametric
-class RobotWrapper[T](FunctorTrait):
+# class RobotWrapper[T](FunctorTrait):
+class RobotWrapper[T](Wrapper):
     name: str
     value: T
 
 
+@overload
 @dispatch
 def fmap(fn: Callable, robot_wrapper: RobotWrapper):
     return RobotWrapper(robot_wrapper.name, fn(robot_wrapper.value))
+
+
+@overload
+@dispatch
+def extract(x: RobotWrapper):
+    return x.value
+
+
+@overload
+@dispatch
+def with_new_value(x: RobotWrapper, value):
+    return RobotWrapper(x.name, value)
+
+
+def string_as_nodesymbol(string):
+    try:
+        c = pddl_char_to_dsg_char(string[0])
+        return NodeSymbol(c, int(string[1:]))
+    except Exception:
+        return None
+
+
+@dispatchable_parametric
+# class SymbolicContext[T](FunctorTrait):
+class SymbolicContext[T](Wrapper):
+    context: dict
+    value: T
+
+
+@dispatch
+def extract(x: SymbolicContext):
+    return x.value
+
+
+@dispatch
+def with_new_value(x: SymbolicContext, value):
+    return SymbolicContext(x.context, value)
+
+
+@dispatch
+def fmap(fn: Callable, v: SymbolicContext):
+    return SymbolicContext(v.context, fn(v.value))
+
+
+class DsgNodeContext(UserDict):
+    def __init__(self, dsg_dict, external_dict):
+        super().__init__()
+        self.dsg_dict = dsg_dict
+        self.external_dict = external_dict
+        self.data = dsg_dict | external_dict
+
+    def __setitem__(self, key, value):
+        if key in self.dsg_dict:
+            raise Exception("Cannot override DSG context")
+        self.external_dict[key] = value
+        self.data[key] = value
+
+
+class DsgContextProvider(dict):
+    def __init__(self, dsg):
+        self.dsg = dsg
+
+    def __getitem__(self, key):
+        ns = string_as_nodesymbol(key)
+        symbol_info = {}
+        if ns is not None:
+            node = self.dsg.find_node(ns)
+            if node is not None:
+                symbol_info["position"] = node.attributes.position
+                node_layer = node.layer.layer
+                node_partition = node.layer.partition
+                category = self.dsg.get_labelspace(
+                    node_layer, node_partition
+                ).get_node_category(node)
+                symbol_info["semantic_label"] = category
+
+        try:
+            explicit_symbols = dict.__getitem__(self, key)
+        except KeyError:
+            dict.__setitem__(self, key, {})
+            explicit_symbols = dict.__getitem__(self, key)
+        return DsgNodeContext(symbol_info, explicit_symbols)
+
+    def __setitem__(self, key, val):
+        if not isinstance(val, dict):
+            raise TypeError(
+                "Context value must be a dictionary, e.g., {context_key: context_value}"
+            )
+        dict.__setitem__(self, key, val)
+
+    def __contains__(self, key):
+        if dict.__contains__(self, key) and len(dict.__getitem__(self, key)) > 0:
+            return True
+
+        ns = string_as_nodesymbol(key)
+        if ns is None:
+            return False
+        return self.dsg.find_node(ns) is not None
+
+
+def collect_plans(plans) -> dict:
+    """Currently assumes plans is either a RobotWrapper or a list of RobotWrappers."""
+    robot_to_plan = {}
+    match plans:
+        case list() | set():
+            for p in plans:
+                if p.name not in robot_to_plan:
+                    robot_to_plan[p.name] = p.value
+                else:
+                    raise Exception(
+                        f"Received duplicate plans for robot {p.name}: {p.value} vs. {robot_to_plan[p.name]}"
+                    )
+        case RobotWrapper():
+            robot_to_plan[plans.name] = plans.value
+        case FunctorTrait():
+            robot_to_plan = fmap(collect_plans, plans)
+        case _:
+            raise Exception(f"Unsure how to process plans of type: {type(plans)}")
+
+    return robot_to_plan
 
 
 class DispatchException(Exception):
@@ -105,11 +248,18 @@ def full_planning_pipeline(plan_request: PlanRequest, map_context: Any, feedback
         feedback,
     )
     logger.debug("Grounded Problem")
-    plan = make_plan(grounded_problem, map_context)
+
+    # TODO: it would be nice if we could incorporate additional symbol context
+    # added during grounding...
+    dsg_context = DsgContextProvider(map_context)
+    contextualized_problem = SymbolicContext(dsg_context, grounded_problem)
+    plan = make_plan(contextualized_problem, map_context)
     logger.debug(f"Made plan {plan}")
     return plan
 
 
-@singledispatch
-def compile_plan(plan, plan_id, robot_name, frame_id):
-    raise NotImplementedError(f"No `compile_plan` implementation for {type(plan)}")
+# TODO: probably want sort of "identity" fallback for compile_plan, so that we
+# can test the compile_plan pipeline without the ROS-specific targeting?
+# @dispatch
+# def compile_plan(plan, plan_id, robot_name, frame_id):
+#    raise NotImplementedError(f"No `compile_plan` implementation for {type(plan)}")

--- a/omniplanner/src/omniplanner/omniplanner.py
+++ b/omniplanner/src/omniplanner/omniplanner.py
@@ -110,7 +110,6 @@ def string_as_nodesymbol(string):
 
 
 @dispatchable_parametric
-# class SymbolicContext[T](FunctorTrait):
 class SymbolicContext[T](Wrapper):
     context: dict
     value: T
@@ -187,28 +186,6 @@ class DsgContextProvider(dict):
         return self.dsg.find_node(ns) is not None
 
 
-def collect_plans(plans) -> dict:
-    """Currently assumes plans is either a RobotWrapper or a list of RobotWrappers."""
-    robot_to_plan = {}
-    match plans:
-        case list() | set():
-            for p in plans:
-                if p.name not in robot_to_plan:
-                    robot_to_plan[p.name] = p.value
-                else:
-                    raise Exception(
-                        f"Received duplicate plans for robot {p.name}: {p.value} vs. {robot_to_plan[p.name]}"
-                    )
-        case RobotWrapper():
-            robot_to_plan[plans.name] = plans.value
-        case FunctorTrait():
-            robot_to_plan = fmap(collect_plans, plans)
-        case _:
-            raise Exception(f"Unsure how to process plans of type: {type(plans)}")
-
-    return robot_to_plan
-
-
 class DispatchException(Exception):
     def __init__(self, function_name, *objects):
         arg_type_string = ", ".join(map(lambda x: x.__name__, map(type, objects)))
@@ -256,10 +233,3 @@ def full_planning_pipeline(plan_request: PlanRequest, map_context: Any, feedback
     plan = make_plan(contextualized_problem, map_context)
     logger.debug(f"Made plan {plan}")
     return plan
-
-
-# TODO: probably want sort of "identity" fallback for compile_plan, so that we
-# can test the compile_plan pipeline without the ROS-specific targeting?
-# @dispatch
-# def compile_plan(plan, plan_id, robot_name, frame_id):
-#    raise NotImplementedError(f"No `compile_plan` implementation for {type(plan)}")

--- a/omniplanner/src/omniplanner/tsp.py
+++ b/omniplanner/src/omniplanner/tsp.py
@@ -104,12 +104,10 @@ def two_opt(route, cost_mat):
                 if j - i == 1:
                     continue
                 delta = cost_change(best[i - 1], best[i], best[j - 1], best[j])
-                logger.warning(f"Delta: {delta}")
                 if delta < -0.0001:
                     best[i:j] = best[j - 1 : i - 1 : -1]
                     improved = True
         route = best
-        logger.warning(f"Best: {best}")
     return best
 
 
@@ -168,7 +166,6 @@ def ground_problem(
     referenced_points = np.vstack([start, referenced_points])
 
     layer_planner = LayerPlanner(dsg, spark_dsg.DsgLayers.MESH_PLACES)
-    logger.warning("Made layer planner")
 
     # Compute pairwise distance matrix based on places
     n = len(referenced_points)
@@ -180,7 +177,6 @@ def ground_problem(
                 referenced_points[ix], referenced_points[jx]
             )
     distance_matrix += distance_matrix.T
-    logger.warning("Computed distance matrix")
 
     return RobotWrapper(
         goal.robot_id,
@@ -191,7 +187,6 @@ def ground_problem(
 @dispatch
 def make_plan(grounded_problem: GroundedTspProblem, map_context: Any) -> FollowPathPlan:
     logger.warning("Making TSP Plan")
-    logger.info(f"goal points: {grounded_problem.goal_points}")
 
     match grounded_problem.solver:
         case "2opt":
@@ -202,14 +197,12 @@ def make_plan(grounded_problem: GroundedTspProblem, map_context: Any) -> FollowP
                 f"Requested TSP Solver not implemented: {grounded_problem.solver})"
             )
 
-    logger.warning(f"tsp order: {tsp_order}")
     tsp_points = grounded_problem.goal_points[tsp_order]
 
     plan = FollowPathPlan([])
 
     layer_planner = LayerPlanner(map_context, spark_dsg.DsgLayers.MESH_PLACES)
     for idx in range(len(tsp_points) - 1):
-        logger.warning(f"Computed external path {idx}")
         path = layer_planner.get_external_path(tsp_points[idx], tsp_points[idx + 1])
         p = FollowPathPrimitive(path)
         plan.steps.append(p)

--- a/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 
 import numpy as np
 import spark_config as sc
 from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal, GotoPointsPlan
-from omniplanner.omniplanner import PlanRequest, compile_plan
+from omniplanner.omniplanner import PlanRequest
 from omniplanner_msgs.msg import GotoPointsGoalMsg
+from plum import dispatch
 from robot_executor_interface.action_descriptions import ActionSequence, Follow
 
 
-@compile_plan.register
-def compile_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
+def compile_points_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
     actions = []
     for p in plan.plan:
         xs = np.interp(np.linspace(0, 1, 10), [0, 1], [p.start[0], p.goal[0]])
@@ -21,6 +22,11 @@ def compile_plan(plan: GotoPointsPlan, plan_id, robot_name, frame_id):
 
     seq = ActionSequence(plan_id=plan_id, robot_name=robot_name, actions=actions)
     return seq
+
+
+@dispatch
+def compile_plan(adaptor, p: GotoPointsPlan):
+    return compile_points_plan(p, str(uuid.uuid4()), adaptor.name, adaptor.parent_frame)
 
 
 class GotoPointsRos:

--- a/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/goto_points_ros.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass
 
 import numpy as np
+import omniplanner.compile_plan  # NOQA
 import spark_config as sc
 from omniplanner.goto_points import GotoPointsDomain, GotoPointsGoal, GotoPointsPlan
 from omniplanner.omniplanner import PlanRequest

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -10,8 +10,8 @@ import rclpy.duration
 import tf2_ros
 import tf_transformations
 from hydra_ros import DsgSubscriber
-from omniplanner.compile_plan import compile_plan
-from omniplanner.omniplanner import collect_plans, full_planning_pipeline
+from omniplanner.compile_plan import collect_plans, compile_plan
+from omniplanner.omniplanner import full_planning_pipeline
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
@@ -11,7 +10,8 @@ import rclpy.duration
 import tf2_ros
 import tf_transformations
 from hydra_ros import DsgSubscriber
-from omniplanner.omniplanner import compile_plan, full_planning_pipeline
+from omniplanner.compile_plan import compile_plan
+from omniplanner.omniplanner import collect_plans, full_planning_pipeline
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
@@ -155,35 +155,6 @@ class RobotPlanningAdaptor:
         self.plan_pub.publish(plan)
 
 
-def collect_plans(plans) -> dict:
-    """Currently assumes plans is either a RobotWrapper or a list of RobotWrappers."""
-    robot_to_plan = {}
-    if isinstance(plans, list):
-        for p in plans:
-            if p.name not in robot_to_plan:
-                robot_to_plan[p.name] = p.value
-            else:
-                raise Exception(
-                    f"Received duplicate plans for robot {p.name}: {p.value} vs. {robot_to_plan[p.name]}"
-                )
-    else:
-        robot_to_plan[plans.name] = plans.value
-
-    return robot_to_plan
-
-
-# NOTE: What's the best way to deal with multiple robots / robot discovery?
-# Probably tie into the general robot discovery mechanism we were thinking
-# about for multi-robot SLAM. Listen for messages broadcast from each robot on
-# shared "bus" topic that identifies the robot id and its transform names. In
-# this node, we can store a mapping from "robot type" to supported planners (I
-# guess, each plugin specifies what robots it can run on). For each robot that
-# appears, we create a publisher that can publish compiled plans.  If there are
-# multiple robots, goal messages may need to specify which robot they are for.
-# Some, such as NaturalLanguage, don't need to specify which robot they are for
-# because the robot allocation is explicitly part of the planning process.
-
-
 class OmniPlannerRos(Node):
     def __init__(self):
         super().__init__("omniplanner_ros")
@@ -208,10 +179,6 @@ class OmniPlannerRos(Node):
         self.dsg_lock = threading.Lock()
         DsgSubscriber(self, "~/dsg_in", self.dsg_callback)
 
-        # TODO: need to generalize this cross robots.
-        # When we discover a new robot, we should create a new
-        # publisher based on the information that the robot provides.
-        # Then we can look up the relevant publisher in the {name: publishers} map
         latching_qos = QoSProfile(
             depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL
         )
@@ -331,18 +298,12 @@ class OmniPlannerRos(Node):
                     plan_request, self.dsg_last, self.feedback
                 )
 
-            robot_to_plan = collect_plans(plans)
-
-            for robot_name, robot_plan in robot_to_plan.items():
-                robot_adaptor = self.robot_adaptors[robot_name]
-                command_frame = robot_adaptor.parent_frame
-                if self.plan_vocalizer is not None:
-                    self.plan_vocalizer.vocalize(robot_name, plan_to_string(robot_plan))
-                compiled_plan = compile_plan(
-                    robot_plan, str(uuid.uuid4()), robot_name, command_frame
-                )
-                robot_adaptor.publish_plan(to_msg(compiled_plan))
-
+            compiled_plans = compile_plan(self.robot_adaptors, plans)
+            plan_dict = collect_plans(compiled_plans)
+            for robot_name, compiled_plan in plan_dict.items():
+                self.robot_adaptors[robot_name].publish_plan(to_msg(compiled_plan))
+                # TODO: combine markers into single array so that latching works
+                # correctly for multi-robot plans?
                 self.compiled_plan_viz_pub.publish(
                     to_viz_msg(compiled_plan, robot_name)
                 )


### PR DESCRIPTION
Add the ability to attach a symbolic context wrapper to the planning pipeline. This involved an extremely long detour through defining semantics for the composition and swapping of wrapper metadata, and a refactoring of compile_plan.

It's a pretty cool system, although perhaps hard to debug, and probably pretty hard to understand the inner workings...