### PR TITLE
Fix/zenoh qos

### DIFF
--- a/omniplanner/src/dsg_pddl/pddl_planning.py
+++ b/omniplanner/src/dsg_pddl/pddl_planning.py
@@ -20,7 +20,7 @@ def solve_pddl(problem: GroundedPddlProblem):
             fo.write(problem.problem_str)
 
         with open(domain_fn, "w") as fo:
-            fo.write(problem.domain.to_pddl_string())
+            fo.write(problem.domain.to_string())
 
         command = ["fast-downward"]
         command += ["--plan-file", plan_fn]

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -210,6 +210,13 @@ class OmniPlannerRos(Node):
             history=QoSHistoryPolicy.KEEP_ALL,
         )
 
+        reliable_blocking_qos = QoSProfile(
+            depth=1,
+            durability=QoSDurabilityPolicy.VOLATILE,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            history=QoSHistoryPolicy.KEEP_ALL,
+        )
+
         self.compiled_plan_viz_pub = self.create_publisher(
             MarkerArray, "~/compiled_plan_viz_out", qos_profile=latching_reliable_qos
         )
@@ -233,7 +240,7 @@ class OmniPlannerRos(Node):
         self.robot_adaptors = {}
         for robot_config in self.config.robots:
             robot_adaptor = robot_config.create(
-                node=self, tf_buffer=self.tf_buffer, qos_profile=latching_reliable_qos
+                node=self, tf_buffer=self.tf_buffer, qos_profile=reliable_blocking_qos
             )
             self.get_logger().info(
                 f"I know about {robot_adaptor.name}, a {robot_adaptor.robot_type} robot"

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -87,7 +87,7 @@ class PlannerConfig(Config):
 
 
 class RobotPlanningAdaptor:
-    def __init__(self, config, node=None, tf_buffer=None):
+    def __init__(self, config, node=None, tf_buffer=None, qos_profile=None):
         self.tf_buffer = tf_buffer
         self.name = config.robot_name
         self.robot_type = config.robot_type
@@ -95,7 +95,9 @@ class RobotPlanningAdaptor:
         self.ros_logger = node.get_logger()
 
         self.plan_pub = node.create_publisher(
-            ActionSequenceMsg, f"/{self.name}/omniplanner_node/compiled_plan_out", 1
+            ActionSequenceMsg,
+            f"/{self.name}/omniplanner_node/compiled_plan_out",
+            qos_profile or 1,
         )
 
     def get_pose(self, parent_frame):
@@ -230,7 +232,9 @@ class OmniPlannerRos(Node):
 
         self.robot_adaptors = {}
         for robot_config in self.config.robots:
-            robot_adaptor = robot_config.create(node=self, tf_buffer=self.tf_buffer)
+            robot_adaptor = robot_config.create(
+                node=self, tf_buffer=self.tf_buffer, qos_profile=latching_reliable_qos
+            )
             self.get_logger().info(
                 f"I know about {robot_adaptor.name}, a {robot_adaptor.robot_type} robot"
             )

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -16,7 +16,12 @@ from omniplanner.omniplanner import full_planning_pipeline
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from rclpy.qos import (
+    QoSDurabilityPolicy,
+    QoSHistoryPolicy,
+    QoSProfile,
+    QoSReliabilityPolicy,
+)
 from robot_executor_interface_ros.action_descriptions_ros import to_msg, to_viz_msg
 from robot_executor_msgs.msg import ActionSequenceMsg
 from robot_vocalizer.plan_vocalizer import PlanVocalizer
@@ -196,11 +201,15 @@ class OmniPlannerRos(Node):
         self.dsg_lock = threading.Lock()
         DsgSubscriber(self, "~/dsg_in", self.dsg_callback)
 
-        latching_qos = QoSProfile(
-            depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL
+        latching_reliable_qos = QoSProfile(
+            depth=1,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            history=QoSHistoryPolicy.KEEP_ALL,
         )
+
         self.compiled_plan_viz_pub = self.create_publisher(
-            MarkerArray, "~/compiled_plan_viz_out", qos_profile=latching_qos
+            MarkerArray, "~/compiled_plan_viz_out", qos_profile=latching_reliable_qos
         )
 
         self.heartbeat_pub = self.create_publisher(NodeInfoMsg, "~/node_status", 1)


### PR DESCRIPTION
Changes the zenoh qos settings to never drop messages for the compiled plans:

See this issue: [https://github.com/ros2/rmw_zenoh/issues/696](https://github.com/ros2/rmw_zenoh/issues/696)

> Change your Publisher QoS to be RELIABLE + KEEP_ALL. rmw_zenoh will apply a CongestionControl::Block` strategy that will block each publication until it's fully pushed on the network. For a periodic Publisher, this might slow down its frequency.

This might not be our only issue but it seems like the strategy we want for publishing plans

Also fixes a typo in the refactor with the to_string method.