### PR TITLE
Plan-repair (1/3): constraints on PddlGoal + grounding-level filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,30 @@ planners:
       type: Pddl
       domain_name: RegionObjectRearrangementDomain
 ```
+## Fast Downward Configuration
+
+The PDDL solver invocation in `solve_pddl`
+(`omniplanner/src/dsg_pddl/pddl_planning.py`) can be tuned at runtime via
+environment variables, without modifying source. This is useful for comparing
+search strategies on a per-launch basis or capping planning time in deployment.
+
+| Variable | Description |
+| --- | --- |
+| `ADT4_FD_ALIAS` | Fast Downward alias (e.g. `seq-sat-lama-2011`). When set, takes precedence over `ADT4_FD_SEARCH` and no `--search` argument is passed. |
+| `ADT4_FD_SEARCH` | Raw string forwarded to Fast Downward's `--search` flag. Ignored if `ADT4_FD_ALIAS` is set. |
+| `ADT4_FD_OVERALL_TIME_LIMIT` | Forwarded as `--overall-time-limit` (e.g. `30s`, `5m`). |
+
+If none of these are set, Omniplanner uses the default:
+`let(hff, ff(), let(hcea, cea(), lazy_greedy([hff, hcea], preferred=[hff, hcea])))`.
+
+Example — run the LAMA alias with a 60-second cap:
+
+```bash
+export ADT4_FD_ALIAS=seq-sat-lama-2011
+export ADT4_FD_OVERALL_TIME_LIMIT=60s
+ros2 launch ...
+```
+
 
 ## Notes
 

--- a/omniplanner/src/dsg_pddl/dsg_pddl_grounding_multirobot.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_grounding_multirobot.py
@@ -33,8 +33,36 @@ from omniplanner.tsp import LayerPlanner
 logger = logging.getLogger(__name__)
 
 
-def generate_dense_region_symbol_connectivity_multirobot(G, symbols, robot_states):
+def _extract_forbidden_sets(constraints):
+    """Pull forbidden POIs and forbidden edges out of a list of ConstraintFact-like objects.
+
+    Each entry is expected to have `predicate` and `symbols` attributes
+    (matches both the Python dataclass and the ROS `ConstraintFact` message).
+    """
+    forbidden_pois = set()
+    forbidden_edges = set()
+    for c in constraints or []:
+        if c.predicate == "forbidden-poi" and len(c.symbols) >= 1:
+            forbidden_pois.add(c.symbols[0])
+        elif c.predicate == "forbidden-edge" and len(c.symbols) >= 2:
+            # Store unordered so we match either direction
+            forbidden_edges.add(tuple(sorted([c.symbols[0], c.symbols[1]])))
+    return forbidden_pois, forbidden_edges
+
+
+def _edge_allowed(s, t, forbidden_pois, forbidden_edges):
+    if s.symbol in forbidden_pois or t.symbol in forbidden_pois:
+        return False
+    if tuple(sorted([s.symbol, t.symbol])) in forbidden_edges:
+        return False
+    return True
+
+
+def generate_dense_region_symbol_connectivity_multirobot(
+    G, symbols, robot_states, constraints=None
+):
     symbol_lookup = {s.symbol: s for s in symbols}
+    forbidden_pois, forbidden_edges = _extract_forbidden_sets(constraints)
     try:
         places_layer = G.get_layer(spark_dsg.DsgLayers.MESH_PLACES)
     except Exception:
@@ -64,7 +92,7 @@ def generate_dense_region_symbol_connectivity_multirobot(G, symbols, robot_state
         10,
         layer_planner,
     )
-    start_connection_threshold = 50
+    start_connection_threshold = 20
     for robot_id in robot_states.keys():
         start_symbol_key = f"pstart{robot_id}"
         if start_symbol_key in symbol_lookup:
@@ -77,6 +105,20 @@ def generate_dense_region_symbol_connectivity_multirobot(G, symbols, robot_state
                 d = layer_planner.get_external_distance(start_position, s.position)
                 if d < start_connection_threshold:
                     edges.append((start_symbol, s, d))
+
+    if forbidden_pois or forbidden_edges:
+        before = len(edges)
+        edges = [
+            e
+            for e in edges
+            if _edge_allowed(e[0], e[1], forbidden_pois, forbidden_edges)
+        ]
+        logger.info(
+            "Dropped %d connectivity edges due to runtime constraints (%d forbidden POIs, %d forbidden edges)",
+            before - len(edges),
+            len(forbidden_pois),
+            len(forbidden_edges),
+        )
 
     return edges
 
@@ -97,9 +139,10 @@ def generate_dense_region_init_multirobot(
     G: spark_dsg.DynamicSceneGraph,
     symbols_of_interest: List[PddlSymbol],
     robot_states: Dict[str, np.ndarray],
+    constraints=None,
 ) -> List[tuple]:
     connectivity = generate_dense_region_symbol_connectivity_multirobot(
-        G, symbols_of_interest, robot_states
+        G, symbols_of_interest, robot_states, constraints=constraints
     )
     connectivity_pddl = symbol_connectivity_to_pddl(connectivity)
 
@@ -146,8 +189,14 @@ def generate_multirobot_region_pddl(
     G: spark_dsg.DynamicSceneGraph,
     raw_pddl_goal_string: str,
     robot_states: np.ndarray,
+    constraints=None,
 ) -> Tuple[str, List[PddlSymbol]]:
-    """Generate a multi-robot PDDL problem for domain region-object-rearrangement-domain-multirobot-fd."""
+    """Generate a multi-robot PDDL problem for domain region-object-rearrangement-domain-multirobot-fd.
+
+    If ``constraints`` is non-empty, the corresponding ``(connected ...)`` facts
+    are dropped from the generated PDDL ``:init`` so the planner cannot path
+    through forbidden POIs / edges. The domain itself is unchanged.
+    """
     # Collect all places/objects/regions and positions
     symbols = extract_all_symbols(G)
     normalize_symbols(symbols)
@@ -179,7 +228,7 @@ def generate_multirobot_region_pddl(
     robot_ids = [rid for rid, pose in robot_states.items() if pose is not None]
     # Build init facts via shared helpers
     init_facts_tuples: List[tuple] = generate_dense_region_init_multirobot(
-        G, symbols_of_interest, robot_states
+        G, symbols_of_interest, robot_states, constraints=constraints
     )
 
     # Ensure robot symbols exist (with positions) for downstream planners
@@ -245,7 +294,10 @@ def ground_problem(
 
         case "region-object-rearrangement-domain-multirobot-fd":
             pddl_problem, symbols = generate_multirobot_region_pddl(
-                dsg, goal.pddl_goal, pddl_compliant_robot_states
+                dsg,
+                goal.pddl_goal,
+                pddl_compliant_robot_states,
+                constraints=goal.constraints,
             )
             # logger.warning(f"!!!!!!!!!!!!!!pddl_problem: {pddl_problem}")
         case _:

--- a/omniplanner/src/dsg_pddl/dsg_pddl_planning.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_planning.py
@@ -76,7 +76,7 @@ def parameterize_place_object_multirobot(layer_planner, symbols, action, last_po
 def make_plan(grounded_problem: GroundedPddlProblem, map_context: Any) -> PddlPlan:
     plan = solve_pddl(grounded_problem)
 
-    logger.warning(f"Made plan {plan}")
+    logger.debug(f"Made plan {plan}")
 
     parameterized_plan = []
 

--- a/omniplanner/src/dsg_pddl/pddl_grounding.py
+++ b/omniplanner/src/dsg_pddl/pddl_grounding.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import Dict, List, Optional
 
@@ -83,9 +83,22 @@ class PddlProblem:
 
 
 @dataclass
+class ConstraintFact:
+    """A runtime constraint fact applied during grounding.
+
+    `predicate` is the PDDL predicate name (e.g. "forbidden-poi").
+    `symbols` is the ordered list of PDDL symbols the predicate is applied to.
+    """
+
+    predicate: str
+    symbols: list  # list[str]
+
+
+@dataclass
 class PddlGoal:
     pddl_goal: str
     robot_id: str
+    constraints: list = field(default_factory=list)  # list[ConstraintFact]
 
 
 # TODO: need to reexamine this whole parsing framework as some point.

--- a/omniplanner/src/dsg_pddl/pddl_planning.py
+++ b/omniplanner/src/dsg_pddl/pddl_planning.py
@@ -11,8 +11,21 @@ from dsg_pddl.pddl_utils import lisp_string_to_ast
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_FD_SEARCH = (
+    "let(hff, ff(), let(hcea, cea(), lazy_greedy([hff, hcea], preferred=[hff, hcea])))"
+)
+
+
 def solve_pddl(problem: GroundedPddlProblem):
-    """Use fast-downward to solve the given pddl problem"""
+    """Use fast-downward to solve the given pddl problem.
+
+    The Fast Downward invocation can be overridden via environment variables:
+        ADT4_FD_ALIAS              - use a Fast Downward alias (e.g. "seq-sat-lama-2011").
+                                     Takes precedence over ADT4_FD_SEARCH when set.
+        ADT4_FD_SEARCH             - raw value passed after `--search`.
+        ADT4_FD_OVERALL_TIME_LIMIT - value passed via `--overall-time-limit`.
+    When unset, the historical lazy-greedy(ff + cea) search is used.
+    """
     with tempfile.TemporaryDirectory() as tmpdirname:
         now = datetime.now()
         key = str(uuid.uuid4())[:8]
@@ -43,14 +56,20 @@ def solve_pddl(problem: GroundedPddlProblem):
         with open(debug_domain_fn, "w") as fo:
             fo.write(problem.domain.to_string())
 
+        fd_alias = os.getenv("ADT4_FD_ALIAS", "").strip()
+        fd_search = os.getenv("ADT4_FD_SEARCH", "").strip()
+        fd_time_limit = os.getenv("ADT4_FD_OVERALL_TIME_LIMIT", "").strip()
+
         command = ["fast-downward"]
         command += ["--plan-file", plan_fn]
+        if fd_time_limit:
+            command += ["--overall-time-limit", fd_time_limit]
+        if fd_alias:
+            command += ["--alias", fd_alias]
         command += [domain_fn]
         command += [problem_fn]
-        command += [
-            "--search",
-            "let(hff, ff(), let(hcea, cea(), lazy_greedy([hff, hcea], preferred=[hff, hcea])))",
-        ]
+        if not fd_alias:
+            command += ["--search", fd_search or DEFAULT_FD_SEARCH]
 
         logger.warning(f"Calling: {command}")
         return_code = subprocess.run(command)

--- a/omniplanner_msgs/CMakeLists.txt
+++ b/omniplanner_msgs/CMakeLists.txt
@@ -19,6 +19,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LanguageGoalMsg.msg"
   "msg/PddlGoalMsg.msg"
   "msg/PddlGoalMsgList.msg"
+  "msg/ConstraintFact.msg"
+  "msg/ConstrainedPddlGoalMsg.msg"
 )
 
 

--- a/omniplanner_msgs/msg/ConstrainedPddlGoalMsg.msg
+++ b/omniplanner_msgs/msg/ConstrainedPddlGoalMsg.msg
@@ -1,0 +1,8 @@
+# A PDDL goal plus a set of runtime constraints to ground it under.
+#
+# `goal` is the underlying PDDL goal (same fields as a plain PddlGoalMsg).
+# `constraints` is a list of ConstraintFact entries the grounder should respect
+# when constructing the PDDL problem instance (e.g. exclude forbidden POIs/edges
+# from connectivity).
+PddlGoalMsg goal
+ConstraintFact[] constraints

--- a/omniplanner_msgs/msg/ConstraintFact.msg
+++ b/omniplanner_msgs/msg/ConstraintFact.msg
@@ -1,0 +1,7 @@
+# One PDDL fact representing a runtime constraint.
+#
+# `predicate` is the PDDL predicate name, e.g. "forbidden-poi" or "forbidden-edge".
+# `symbols` is the ordered list of PDDL symbols that the predicate is applied to,
+# e.g. ["p123"] for (forbidden-poi p123) or ["p1", "p2"] for (forbidden-edge p1 p2).
+string predicate
+string[] symbols


### PR DESCRIPTION
Adds runtime constraint plumbing for the multi-robot PDDL grounding, without changing any ground_problem / make_plan signatures.

- omniplanner_msgs:
  - new ConstraintFact.msg (predicate + symbol list)
  - new ConstrainedPddlGoalMsg.msg (PddlGoalMsg + list of ConstraintFact)
  - PddlGoalMsg itself is unchanged
- dsg_pddl:
  - PddlGoal gains a 'constraints' field (list[ConstraintFact])
  - multi-robot grounding reads goal.constraints and excludes the (connected ...) facts that would otherwise let the planner path through forbidden POIs / forbidden edges
  - the existing multi-robot domain is unchanged; no new domain file
- pddl_planning.solve_pddl gains optional Fast Downward env-var overrides (ADT4_FD_ALIAS, ADT4_FD_SEARCH, ADT4_FD_OVERALL_TIME_LIMIT); defaults are unchanged
- 'Made plan' log downgraded from warning to debug per review