### PR TITLE
Feature/omniplanner repair node

### DIFF
--- a/omniplanner/src/dsg_pddl/dsg_pddl_grounding_multirobot.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_grounding_multirobot.py
@@ -33,8 +33,36 @@ from omniplanner.tsp import LayerPlanner
 logger = logging.getLogger(__name__)
 
 
-def generate_dense_region_symbol_connectivity_multirobot(G, symbols, robot_states):
+def _extract_forbidden_sets(constraints):
+    """Pull forbidden POIs and forbidden edges out of a list of ConstraintFact-like objects.
+
+    Each entry is expected to have `predicate` and `symbols` attributes
+    (matches both the Python dataclass and the ROS `ConstraintFact` message).
+    """
+    forbidden_pois = set()
+    forbidden_edges = set()
+    for c in constraints or []:
+        if c.predicate == "forbidden-poi" and len(c.symbols) >= 1:
+            forbidden_pois.add(c.symbols[0])
+        elif c.predicate == "forbidden-edge" and len(c.symbols) >= 2:
+            # Store unordered so we match either direction
+            forbidden_edges.add(tuple(sorted([c.symbols[0], c.symbols[1]])))
+    return forbidden_pois, forbidden_edges
+
+
+def _edge_allowed(s, t, forbidden_pois, forbidden_edges):
+    if s.symbol in forbidden_pois or t.symbol in forbidden_pois:
+        return False
+    if tuple(sorted([s.symbol, t.symbol])) in forbidden_edges:
+        return False
+    return True
+
+
+def generate_dense_region_symbol_connectivity_multirobot(
+    G, symbols, robot_states, constraints=None
+):
     symbol_lookup = {s.symbol: s for s in symbols}
+    forbidden_pois, forbidden_edges = _extract_forbidden_sets(constraints)
     try:
         places_layer = G.get_layer(spark_dsg.DsgLayers.MESH_PLACES)
     except Exception:
@@ -78,6 +106,20 @@ def generate_dense_region_symbol_connectivity_multirobot(G, symbols, robot_state
                 if d < start_connection_threshold:
                     edges.append((start_symbol, s, d))
 
+    if forbidden_pois or forbidden_edges:
+        before = len(edges)
+        edges = [
+            e
+            for e in edges
+            if _edge_allowed(e[0], e[1], forbidden_pois, forbidden_edges)
+        ]
+        logger.info(
+            "Dropped %d connectivity edges due to runtime constraints (%d forbidden POIs, %d forbidden edges)",
+            before - len(edges),
+            len(forbidden_pois),
+            len(forbidden_edges),
+        )
+
     return edges
 
 
@@ -97,9 +139,10 @@ def generate_dense_region_init_multirobot(
     G: spark_dsg.DynamicSceneGraph,
     symbols_of_interest: List[PddlSymbol],
     robot_states: Dict[str, np.ndarray],
+    constraints=None,
 ) -> List[tuple]:
     connectivity = generate_dense_region_symbol_connectivity_multirobot(
-        G, symbols_of_interest, robot_states
+        G, symbols_of_interest, robot_states, constraints=constraints
     )
     connectivity_pddl = symbol_connectivity_to_pddl(connectivity)
 
@@ -146,8 +189,14 @@ def generate_multirobot_region_pddl(
     G: spark_dsg.DynamicSceneGraph,
     raw_pddl_goal_string: str,
     robot_states: np.ndarray,
+    constraints=None,
 ) -> Tuple[str, List[PddlSymbol]]:
-    """Generate a multi-robot PDDL problem for domain region-object-rearrangement-domain-multirobot-fd."""
+    """Generate a multi-robot PDDL problem for domain region-object-rearrangement-domain-multirobot-fd.
+
+    If ``constraints`` is non-empty, the corresponding ``(connected ...)`` facts
+    are dropped from the generated PDDL ``:init`` so the planner cannot path
+    through forbidden POIs / edges. The domain itself is unchanged.
+    """
     # Collect all places/objects/regions and positions
     symbols = extract_all_symbols(G)
     normalize_symbols(symbols)
@@ -179,7 +228,7 @@ def generate_multirobot_region_pddl(
     robot_ids = [rid for rid, pose in robot_states.items() if pose is not None]
     # Build init facts via shared helpers
     init_facts_tuples: List[tuple] = generate_dense_region_init_multirobot(
-        G, symbols_of_interest, robot_states
+        G, symbols_of_interest, robot_states, constraints=constraints
     )
 
     # Ensure robot symbols exist (with positions) for downstream planners
@@ -245,7 +294,10 @@ def ground_problem(
 
         case "region-object-rearrangement-domain-multirobot-fd":
             pddl_problem, symbols = generate_multirobot_region_pddl(
-                dsg, goal.pddl_goal, pddl_compliant_robot_states
+                dsg,
+                goal.pddl_goal,
+                pddl_compliant_robot_states,
+                constraints=goal.constraints,
             )
             # logger.warning(f"!!!!!!!!!!!!!!pddl_problem: {pddl_problem}")
         case _:

--- a/omniplanner/src/dsg_pddl/dsg_pddl_planning.py
+++ b/omniplanner/src/dsg_pddl/dsg_pddl_planning.py
@@ -76,7 +76,7 @@ def parameterize_place_object_multirobot(layer_planner, symbols, action, last_po
 def make_plan(grounded_problem: GroundedPddlProblem, map_context: Any) -> PddlPlan:
     plan = solve_pddl(grounded_problem)
 
-    logger.warning(f"Made plan {plan}")
+    logger.debug(f"Made plan {plan}")
 
     parameterized_plan = []
 

--- a/omniplanner/src/dsg_pddl/pddl_grounding.py
+++ b/omniplanner/src/dsg_pddl/pddl_grounding.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import Dict, List, Optional
 
@@ -83,9 +83,22 @@ class PddlProblem:
 
 
 @dataclass
+class ConstraintFact:
+    """A runtime constraint fact applied during grounding.
+
+    `predicate` is the PDDL predicate name (e.g. "forbidden-poi").
+    `symbols` is the ordered list of PDDL symbols the predicate is applied to.
+    """
+
+    predicate: str
+    symbols: list  # list[str]
+
+
+@dataclass
 class PddlGoal:
     pddl_goal: str
     robot_id: str
+    constraints: list = field(default_factory=list)  # list[ConstraintFact]
 
 
 # TODO: need to reexamine this whole parsing framework as some point.

--- a/omniplanner/src/dsg_pddl/pddl_planning.py
+++ b/omniplanner/src/dsg_pddl/pddl_planning.py
@@ -11,8 +11,21 @@ from dsg_pddl.pddl_utils import lisp_string_to_ast
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_FD_SEARCH = (
+    "let(hff, ff(), let(hcea, cea(), lazy_greedy([hff, hcea], preferred=[hff, hcea])))"
+)
+
+
 def solve_pddl(problem: GroundedPddlProblem):
-    """Use fast-downward to solve the given pddl problem"""
+    """Use fast-downward to solve the given pddl problem.
+
+    The Fast Downward invocation can be overridden via environment variables:
+        ADT4_FD_ALIAS              - use a Fast Downward alias (e.g. "seq-sat-lama-2011").
+                                     Takes precedence over ADT4_FD_SEARCH when set.
+        ADT4_FD_SEARCH             - raw value passed after `--search`.
+        ADT4_FD_OVERALL_TIME_LIMIT - value passed via `--overall-time-limit`.
+    When unset, the historical lazy-greedy(ff + cea) search is used.
+    """
     with tempfile.TemporaryDirectory() as tmpdirname:
         now = datetime.now()
         key = str(uuid.uuid4())[:8]
@@ -43,14 +56,20 @@ def solve_pddl(problem: GroundedPddlProblem):
         with open(debug_domain_fn, "w") as fo:
             fo.write(problem.domain.to_string())
 
+        fd_alias = os.getenv("ADT4_FD_ALIAS", "").strip()
+        fd_search = os.getenv("ADT4_FD_SEARCH", "").strip()
+        fd_time_limit = os.getenv("ADT4_FD_OVERALL_TIME_LIMIT", "").strip()
+
         command = ["fast-downward"]
         command += ["--plan-file", plan_fn]
+        if fd_time_limit:
+            command += ["--overall-time-limit", fd_time_limit]
+        if fd_alias:
+            command += ["--alias", fd_alias]
         command += [domain_fn]
         command += [problem_fn]
-        command += [
-            "--search",
-            "let(hff, ff(), let(hcea, cea(), lazy_greedy([hff, hcea], preferred=[hff, hcea])))",
-        ]
+        if not fd_alias:
+            command += ["--search", fd_search or DEFAULT_FD_SEARCH]
 
         logger.warning(f"Calling: {command}")
         return_code = subprocess.run(command)

--- a/omniplanner_msgs/CMakeLists.txt
+++ b/omniplanner_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PddlGoalMsgList.msg"
   "msg/ConstraintFact.msg"
   "msg/ConstrainedPddlGoalMsg.msg"
+  "msg/ConstraintList.msg"
 )
 
 

--- a/omniplanner_msgs/CMakeLists.txt
+++ b/omniplanner_msgs/CMakeLists.txt
@@ -19,6 +19,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LanguageGoalMsg.msg"
   "msg/PddlGoalMsg.msg"
   "msg/PddlGoalMsgList.msg"
+  "msg/ConstraintFact.msg"
+  "msg/ConstrainedPddlGoalMsg.msg"
 )
 
 

--- a/omniplanner_msgs/msg/ConstrainedPddlGoalMsg.msg
+++ b/omniplanner_msgs/msg/ConstrainedPddlGoalMsg.msg
@@ -1,0 +1,8 @@
+# A PDDL goal plus a set of runtime constraints to ground it under.
+#
+# `goal` is the underlying PDDL goal (same fields as a plain PddlGoalMsg).
+# `constraints` is a list of ConstraintFact entries the grounder should respect
+# when constructing the PDDL problem instance (e.g. exclude forbidden POIs/edges
+# from connectivity).
+PddlGoalMsg goal
+ConstraintFact[] constraints

--- a/omniplanner_msgs/msg/ConstraintFact.msg
+++ b/omniplanner_msgs/msg/ConstraintFact.msg
@@ -1,0 +1,7 @@
+# One PDDL fact representing a runtime constraint.
+#
+# `predicate` is the PDDL predicate name, e.g. "forbidden-poi" or "forbidden-edge".
+# `symbols` is the ordered list of PDDL symbols that the predicate is applied to,
+# e.g. ["p123"] for (forbidden-poi p123) or ["p1", "p2"] for (forbidden-edge p1 p2).
+string predicate
+string[] symbols

--- a/omniplanner_msgs/msg/ConstraintList.msg
+++ b/omniplanner_msgs/msg/ConstraintList.msg
@@ -1,0 +1,5 @@
+# Persistent runtime constraints applied to all subsequent planning calls.
+#
+# Publish a fresh ConstraintList on the planner's `~/constraints` topic to
+# replace the active constraint set; publish with an empty list to clear.
+ConstraintFact[] constraints

--- a/omniplanner_ros/setup.py
+++ b/omniplanner_ros/setup.py
@@ -43,6 +43,9 @@ setup(
     license="TODO: License declaration",
     tests_require=["pytest"],
     entry_points={
-        "console_scripts": ["omniplanner_node = omniplanner_ros.omniplanner_node:main"],
+        "console_scripts": [
+            "omniplanner_node = omniplanner_ros.omniplanner_node:main",
+            "omniplanner_repair_node = omniplanner_ros.omniplanner_repair_node:main",
+        ],
     },
 )

--- a/omniplanner_ros/src/omniplanner_ros/multirobot_ros.py
+++ b/omniplanner_ros/src/omniplanner_ros/multirobot_ros.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from importlib.resources import as_file, files
@@ -8,11 +9,51 @@ import dsg_pddl.domains
 import dsg_pddl.dsg_pddl_grounding_multirobot  # noqa: F401
 import dsg_pddl.dsg_pddl_planning  # noqa: F401
 import spark_config as sc
-from dsg_pddl.pddl_grounding import MultiRobotPddlDomain, PddlGoal
-from omniplanner.omniplanner import PlanRequest
-from omniplanner_msgs.msg import PddlGoalMsg
+from dsg_pddl.dsg_pddl_planning import PddlPlan
+from dsg_pddl.pddl_grounding import ConstraintFact, MultiRobotPddlDomain, PddlGoal
+from omniplanner.omniplanner import MultiRobotWrapper, PlanRequest, SymbolicContext
+from omniplanner_msgs.msg import ConstrainedPddlGoalMsg, PddlGoalMsg
+from std_msgs.msg import String
 
 logger = logging.getLogger(__name__)
+
+
+def _peel_symbolic(x):
+    """Strip SymbolicContext layers (may be nested) to expose the inner value."""
+    while isinstance(x, SymbolicContext):
+        x = x.value
+    return x
+
+
+def _extract_visited_pois_from_pipeline(plans):
+    """Return {robot_name -> set(POI ids)} for a multi-robot PDDL pipeline output.
+
+    Mirrors the per-robot split that compile_multirobot_pddl_plan does so the
+    plugin can publish visit-coverage without depending on a side-channel cache.
+    """
+    result: dict[str, set[str]] = {}
+    inner = _peel_symbolic(plans)
+
+    if isinstance(inner, MultiRobotWrapper):
+        plan = _peel_symbolic(inner.value)
+        if not isinstance(plan, PddlPlan):
+            return result
+        for rn in inner.names:
+            result[rn] = set()
+        for sym in plan.symbolic_actions:
+            if len(sym) < 2 or sym[0] != "goto-poi":
+                continue
+            rn = inner.remap_name_to_outer(sym[1])
+            if rn in result:
+                result[rn].add(sym[-1])
+        return result
+
+    if isinstance(inner, PddlPlan) and inner.symbolic_actions:
+        # Single-robot fallback.
+        rn = inner.symbolic_actions[0][1]
+        result[rn] = {sym[-1] for sym in inner.symbolic_actions if sym[0] == "goto-poi"}
+
+    return result
 
 
 class MultiRobotPddlPlannerRos:
@@ -52,3 +93,81 @@ class MultiRobotPddlPlannerRos:
 @dataclass
 class MultiRobotPddlConfig(sc.Config):
     domain_name: str = None
+
+
+class MultiRobotPddlConstrainedPlannerRos(MultiRobotPddlPlannerRos):
+    """Variant of MultiRobotPddlPlannerRos that supports runtime constraints.
+
+    Differences from the base plugin:
+      - Subscribes to ConstrainedPddlGoalMsg instead of PddlGoalMsg.
+      - Merges per-message constraints with the parent node's
+        `active_constraints` (the persistent set, updated via the repair
+        node's ``~/constraints`` topic) before grounding.
+      - Defines an ``on_plan_compiled`` hook which the omniplanner core
+        invokes after a plan is published; it extracts the POIs visited by
+        the freshly compiled plan and publishes them, so the goal manager
+        can decide whether a subsequent goal needs replanning.
+    """
+
+    def __init__(self, config: MultiRobotPddlConstrainedConfig):
+        super().__init__(config)
+        self._node = None
+        self._visited_pois_pubs: dict = {}  # {robot_name -> ROS publisher}
+
+    def get_plan_callback(self):
+        return ConstrainedPddlGoalMsg, "pddl_goal", self.pddl_callback
+
+    def get_plugin_feedback(self, node):
+        self._node = node
+        return None
+
+    def pddl_callback(self, msg: ConstrainedPddlGoalMsg, robot_poses):
+        logger.info(
+            f"Received constrained PDDL goal {msg.goal.pddl_goal} "
+            f"for robot {msg.goal.robot_id} with {len(msg.constraints)} per-msg constraints"
+        )
+
+        persistent = []
+        if self._node is not None:
+            persistent = list(getattr(self._node, "active_constraints", []))
+
+        per_msg = [
+            ConstraintFact(predicate=c.predicate, symbols=list(c.symbols))
+            for c in msg.constraints
+        ]
+        merged = persistent + per_msg
+
+        goal = PddlGoal(
+            pddl_goal=msg.goal.pddl_goal,
+            robot_id=msg.goal.robot_id,
+            constraints=merged,
+        )
+        return PlanRequest(domain=self.domain, goal=goal, robot_states=robot_poses)
+
+    def on_plan_compiled(self, plans, plan_dict):
+        """Publish the set of POIs each robot's freshly compiled plan visits."""
+        if self._node is None:
+            return
+        visited = _extract_visited_pois_from_pipeline(plans)
+        for robot_name, pois in visited.items():
+            pub = self._visited_pois_pubs.get(robot_name)
+            if pub is None:
+                pub = self._node.create_publisher(
+                    String,
+                    f"/{robot_name}/omniplanner_node/plan_visited_pois",
+                    1,
+                )
+                self._visited_pois_pubs[robot_name] = pub
+            msg = String()
+            msg.data = json.dumps(sorted(pois))
+            pub.publish(msg)
+
+
+@sc.register_config(
+    "omniplanner_pipeline",
+    name="MultiRobotPddlConstrained",
+    constructor=MultiRobotPddlConstrainedPlannerRos,
+)
+@dataclass
+class MultiRobotPddlConstrainedConfig(MultiRobotPddlConfig):
+    pass

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_node.py
@@ -340,6 +340,19 @@ class OmniPlannerRos(Node):
                     to_viz_msg(compiled_plan, robot_name)
                 )
 
+            # Plugin extension point: let the plugin react to a freshly
+            # compiled plan (e.g. to publish derived information such as the
+            # set of POIs visited by the new plan). Optional; plugins that
+            # don't define this method are unaffected.
+            on_plan_compiled = getattr(plugin, "on_plan_compiled", None)
+            if on_plan_compiled is not None:
+                try:
+                    on_plan_compiled(plans, plan_dict)
+                except Exception as exc:
+                    self.get_logger().warning(
+                        f"on_plan_compiled hook for plugin {name} raised: {exc}"
+                    )
+
             with self.current_planner_lock and self.plan_time_start_lock:
                 self.current_planner = None
                 self.plan_time_start = None

--- a/omniplanner_ros/src/omniplanner_ros/omniplanner_repair_node.py
+++ b/omniplanner_ros/src/omniplanner_ros/omniplanner_repair_node.py
@@ -1,0 +1,79 @@
+"""Omniplanner node with runtime constraint plumbing.
+
+Thin subclass of :class:`omniplanner_ros.omniplanner_node.OmniPlannerRos` that
+adds support for a persistent set of runtime constraints (e.g.
+``forbidden-poi``/``forbidden-edge``).
+
+Other plugins that want to consume the persistent constraints look at
+``node.active_constraints``; the ``MultiRobotPddlConstrainedPlannerRos``
+plugin in :mod:`omniplanner_ros.multirobot_ros` merges them with
+per-message constraints before grounding.
+
+This module does **not** override ``register_plugin`` or duplicate the
+plan-handling logic in ``OmniPlannerRos``; the plugin-side ``pddl_callback``
+and the upstream ``plugin.on_plan_compiled`` hook handle the per-call work.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import rclpy
+from dsg_pddl.pddl_grounding import ConstraintFact
+from omniplanner_msgs.msg import ConstraintList
+from rclpy.executors import MultiThreadedExecutor
+
+from omniplanner_ros.omniplanner_node import OmniPlannerRos
+
+
+class OmniPlannerRepairRos(OmniPlannerRos):
+    """OmniPlannerRos plus a ``~/constraints`` topic for persistent constraints."""
+
+    def __init__(self):
+        # Initialize constraint state before super().__init__() so plugins
+        # registered during the parent constructor can read it safely if they
+        # need to.
+        self._constraints_lock = threading.Lock()
+        self.active_constraints: list[ConstraintFact] = []
+
+        super().__init__()
+
+        self.create_subscription(
+            ConstraintList,
+            "~/constraints",
+            self._constraints_callback,
+            10,
+        )
+        self.get_logger().info(
+            "OmniPlannerRepairRos listening for persistent constraints on ~/constraints"
+        )
+
+    def _constraints_callback(self, msg: ConstraintList) -> None:
+        new_constraints = [
+            ConstraintFact(predicate=c.predicate, symbols=list(c.symbols))
+            for c in msg.constraints
+        ]
+        with self._constraints_lock:
+            self.active_constraints = new_constraints
+        self.get_logger().info(
+            f"Updated persistent constraints: {len(new_constraints)} fact(s)"
+        )
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    try:
+        node = OmniPlannerRepairRos()
+        executor = MultiThreadedExecutor()
+        executor.add_node(node)
+        try:
+            executor.spin()
+        finally:
+            executor.shutdown()
+            node.destroy_node()
+    finally:
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Plan-repair (2/3): omniplanner_repair_node with constraint merging via plugin 
1. omniplanner_msgs: ConstraintList.msg for persistent ~/constraints topic                                                                                      
2. omniplanner_node: small extension point — plan_handler calls plugin.on_plan_compiled(plans, plan_dict) if defined. Plugins that don't define it are unaffected.                                                                                                                                                    
3. multirobot_ros: new MultiRobotPddlConstrainedPlannerRos plugin                                                                                               
4. subscribes to ConstrainedPddlGoalMsg (from PR 1)                                                                                                         
5. merges persistent constraints from node.active_constraints with per-message constraints into a PddlGoal.constraints list                                 
6. on_plan_compiled hook publishes per-robot visited POIs to /<robot>/omniplanner_node/plan_visited_pois                                                    
7. omniplanner_repair_node: thin OmniPlannerRos subclass — adds ~/constraints topic and active_constraints state. No register_plugin override; no plan-handling duplication.